### PR TITLE
Adjust README and clean script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zkWasm-C
 ## About C template for ZKWASM:
-This is a project template for constructing wasm program for ZKWASM using C language.
+This is a project template for constructing wasm programs for a ZKWASM environment using the C language.
 It contains two directories which are **./sdk** and **./proejct**.
 1. sdk directory:  Contains basic built-in c libraries and head files.
 2. project directory: Contains an example project that can be compiled into a wasm output.
@@ -8,8 +8,9 @@ It contains two directories which are **./sdk** and **./proejct**.
 ## Usage:
 You can modify the code in ./project directory and use **make** to compile the project into output.wasm.
 
-## Building Requirement:
-You need clang (better with version 15) to compile and link C code into wasm.
+## Building Requirements:
+You need [clang](https://github.com/llvm/llvm-project) to compile and link C code into wasm. Recommend version 15 which includes `wasm-ld`.
+
 
 ## Run the output:
 The output.wasm file is a standard web assembly image that can be run using any wasm interpreter which provides necessary host functions. 
@@ -17,3 +18,7 @@ Currently, there are three main scenarios:
 1. run the wasm image in a web environment for web games and generates instances for proof generation. (An example can be found at https://github.com/ZhenXunGe/g1024).
 2. run the wasm image in a backend environment with zkWASM virtual machine and generate proofs for on-chain verification. (See https://github.com/DelphinusLab/zkWasm for the command line usage of zkWASM virtual machine)
 3. run the wasm image in LAYER-TWO that supports zkWASM (currently ZKCross) and let ZCcross do the tedious work of synchronizing and settlement in a cross-chain manner.
+
+
+## Not necessary but included in make:
+`wasm2wat` which can be obtrained [here](https://github.com/WebAssembly/wabt). During `make` from within /sdk/scripts, will output `.wat` files for each ./sdk/c/ subdirectory.

--- a/sdk/scripts/clean.sh
+++ b/sdk/scripts/clean.sh
@@ -7,8 +7,24 @@ TOP_PATH=$SCRIPT_PATH/..
 
 MAKEFILE=$SCRIPT_PATH/Makefile
 
-make clean -C $TOP_PATH/c/sdk/lib -f $MAKEFILE
-make clean -C $TOP_PATH/c/rlp/lib -f $MAKEFILE
-make clean -C $TOP_PATH/c/hash/lib -f $MAKEFILE
-make clean -C $TOP_PATH/c/ecc/lib -f $MAKEFILE
-#make clean -C $TOP_PATH/c/kvpair/lib -f $MAKEFILE
+DIR_SDK_LIB="$TOP_PATH/c/sdk/lib"
+DIR_RLP_LIB="$TOP_PATH/c/rlp/lib"
+DIR_HASH_LIB="$TOP_PATH/c/hash/lib"
+DIR_ECC_LIB="$TOP_PATH/c/ecc/lib"
+DIR_KVPAIR_LIB="$TOP_PATH/c/kvpair/lib"
+
+if [ -d "$DIR_SDK_LIB" ]; then
+    make clean -C $TOP_PATH/c/sdk/lib -f $MAKEFILE
+fi
+if [ -d "$DIR_RLP_LIB" ]; then
+    make clean -C $TOP_PATH/c/rlp/lib -f $MAKEFILE
+fi
+if [ -d "$DIR_HASH_LIB" ]; then
+    make clean -C $TOP_PATH/c/hash/lib -f $MAKEFILE
+fi
+if [ -d "$DIR_ECC_LIB" ]; then
+    make clean -C $TOP_PATH/c/ecc/lib -f $MAKEFILE
+fi
+if [ -d "$DIR_KVPAIR_LIB" ]; then
+    make clean -C $TOP_PATH/c/kvpair/lib -f $MAKEFILE
+fi

--- a/sdk/scripts/clean.sh
+++ b/sdk/scripts/clean.sh
@@ -11,4 +11,4 @@ make clean -C $TOP_PATH/c/sdk/lib -f $MAKEFILE
 make clean -C $TOP_PATH/c/rlp/lib -f $MAKEFILE
 make clean -C $TOP_PATH/c/hash/lib -f $MAKEFILE
 make clean -C $TOP_PATH/c/ecc/lib -f $MAKEFILE
-make clean -C $TOP_PATH/c/kvpair/lib -f $MAKEFILE
+#make clean -C $TOP_PATH/c/kvpair/lib -f $MAKEFILE


### PR DESCRIPTION
**Adjustments:**

Small additions to README.md to include link to llvm emphasis on `wasm-ld` v15 and wasm2wat for reader.

Modify clean.sh in sdk/c/scripts/ to ignore non existent lib directories because `make clean` bounces on /kvpair/lib if it does not exist (which it does not currently).


